### PR TITLE
Update the travis config to test on node 8/10/12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@
 language: node_js
 matrix:
   include:
-    - node_js: '4'
-    - node_js: '5'
-    - node_js: '6'
+    - node_js: '8'
+    - node_js: '10'
+    - node_js: '12'
 
 # Build only master (and pull-requests)
 branches:


### PR DESCRIPTION
This commit drops versions 4, 5 and 6 from the travis config, and replace them with versions 8, 10 and 12.

We broadly follow the [Springer Nature Open Source support guidelines](https://github.com/springernature/frontend-playbook/blob/14ea315e877a8941cc995c6433250a793cffa85f/practices/open-source-support.md#node-versions) with regards to the Node versions that we support.

We aim to support every version that the Node foundation offers [Long-term support (LTS)](https://github.com/nodejs/Release) for, so at the time of writing this is versions 8 and 10, plus version 12 which will become the next LTS.